### PR TITLE
    Prevent redundant sorting in BubbleSortLinked

### DIFF
--- a/SortAlg/BubbleSortLinked.c
+++ b/SortAlg/BubbleSortLinked.c
@@ -26,6 +26,8 @@ void Bubblesort(Node *head, Node *tail)
 
         current = current->next;
     }
+    if (trocou == 0) return;
+
     Bubblesort(current, anterior);
 }
 


### PR DESCRIPTION
    Added an early return when no swaps occur during a pass, optimizing performance by halting sorting when the list is already sorted. This avoids unnecessary iterations and improves efficiency.